### PR TITLE
Fix Windows PowerShell Double-Trigger Bug

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{self, Event, KeyEvent};
+use crossterm::event::{self, Event, KeyEvent, KeyEventKind};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -38,7 +38,7 @@ impl EventHandler {
             while !term_cancel.is_cancelled() {
                 if event::poll(Duration::from_millis(50)).unwrap_or(false) {
                     match event::read() {
-                        Ok(Event::Key(key)) => {
+                        Ok(Event::Key(key)) if key.kind == KeyEventKind::Press => {
                             if term_tx.send(AppEvent::Key(key)).is_err() {
                                 break;
                             }


### PR DESCRIPTION

# Fix Windows PowerShell Double-Trigger Bug

## Root Cause

On Windows, crossterm emits **separate `KeyEvent`s for both key press and key release** (and sometimes repeat). On macOS/Linux terminals, only press events are typically emitted. Since the event handler in [src/event.rs](src/event.rs) forwards **all** `KeyEvent`s without checking `KeyEvent.kind`, every physical keypress results in two actions on Windows: one for `Press` and one for `Release`.

The bug is at line 41-44 of `event.rs`:

```41:44:src/event.rs
                        Ok(Event::Key(key)) => {
                            if term_tx.send(AppEvent::Key(key)).is_err() {
                                break;
                            }
                        }
```

There is no check on `key.kind`. The `KeyEvent` struct in crossterm 0.29 has a `kind` field of type `KeyEventKind` with variants `Press`, `Release`, and `Repeat`.

## Fix

In [src/event.rs](src/event.rs), add a filter so only `KeyEventKind::Press` events are forwarded. This is a one-line guard addition:

```rust
use crossterm::event::{self, Event, KeyEvent, KeyEventKind};
// ...
Ok(Event::Key(key)) => {
    if key.kind == KeyEventKind::Press {
        if term_tx.send(AppEvent::Key(key)).is_err() {
            break;
        }
    }
}
```

This is the standard fix for this well-known crossterm Windows behavior. It matches what ratatui's own examples and templates recommend.

## Why `Repeat` is excluded

`KeyEventKind::Repeat` fires when a key is held down. Excluding it keeps behavior consistent with macOS (where repeat events show up as additional `Press` events). If held-key scrolling feels sluggish on Windows after this fix, `Repeat` can be added back with `key.kind == KeyEventKind::Press || key.kind == KeyEventKind::Repeat`, but it's safer to start with `Press`-only and add `Repeat` if needed.

## Files Changed

- **[src/event.rs](src/event.rs)** -- add `KeyEventKind` import and filter guard (2-line change)


---
**Stack**:
- #3 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*