### PR TITLE
Allow e to toggle comments as well

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -453,8 +453,14 @@ impl App {
             // Comment
             KeyCode::Char('c') => self.start_comment(),
 
-            // Expand context
-            KeyCode::Char('e') => self.request_expand(),
+            // Expand context or toggle comment
+            KeyCode::Char('e') => {
+                if self.diff_view.toggle_comment_expand() {
+                    self.rebuild_display();
+                } else {
+                    self.request_expand();
+                }
+            }
 
             // Review actions — show confirmation popup
             KeyCode::Char('a') => self.review_confirm.show(ReviewEvent::Approve, self.pending_comments.len()),


### PR DESCRIPTION
e now first tries to toggle a comment expand/collapse (via toggle_comment_expand, which returns true only when the cursor is on a comment header row). If the cursor isn't on a comment, it falls back to the original behavior of expanding diff context via request_expand()

---
**Stack**:
- #5
- #4 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*