### PR TITLE
Support reply to comments

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -197,13 +197,17 @@ impl App {
             let input: Input = key.into();
             match self.comment_input.handle_input(input) {
                 CommentAction::Submit(body) => {
-                    self.pending_comments.push(ReviewComment {
-                        path: self.comment_input.file_path.clone(),
-                        line: self.comment_input.line,
-                        side: self.comment_input.side,
-                        body,
-                    });
-                    self.rebuild_display();
+                    if let Some(comment_id) = self.comment_input.reply_to_id {
+                        self.submit_reply(comment_id, body);
+                    } else {
+                        self.pending_comments.push(ReviewComment {
+                            path: self.comment_input.file_path.clone(),
+                            line: self.comment_input.line,
+                            side: self.comment_input.side,
+                            body,
+                        });
+                        self.rebuild_display();
+                    }
                 }
                 CommentAction::Cancel => {}
                 CommentAction::None => {}
@@ -450,8 +454,15 @@ impl App {
             // View toggle
             KeyCode::Char('t') => self.diff_view.toggle_mode(),
 
-            // Comment
-            KeyCode::Char('c') => self.start_comment(),
+            // Comment: reply on comment row, new comment on diff line
+            KeyCode::Char('c') => {
+                if let Some(target) = self.diff_view.comment_reply_target() {
+                    self.comment_input
+                        .open_reply(target.github_id, target.author);
+                } else {
+                    self.start_comment();
+                }
+            }
 
             // Expand context or toggle comment
             KeyCode::Char('e') => {
@@ -555,6 +566,32 @@ impl App {
                 }
                 Err(e) => {
                     let _ = tx.send(AppEvent::Error(format!("Submit failed: {e}")));
+                }
+            }
+        });
+    }
+
+    fn submit_reply(&mut self, comment_id: u64, body: String) {
+        let tx = self.tx.clone();
+        let repo = self.repo.clone();
+        let pr = self.pr_number;
+
+        self.status_msg = "Posting reply...".to_string();
+        self.status_is_error = false;
+
+        tokio::spawn(async move {
+            match crate::gh::reply_to_comment(&repo, pr, comment_id, &body).await {
+                Ok(()) => {
+                    let _ = tx.send(AppEvent::ReviewSubmitted);
+                    match crate::gh::fetch_review_comments(&repo, pr).await {
+                        Ok(comments) => {
+                            let _ = tx.send(AppEvent::CommentsLoaded(comments));
+                        }
+                        Err(_) => {}
+                    }
+                }
+                Err(e) => {
+                    let _ = tx.send(AppEvent::Error(format!("Reply failed: {e}")));
                 }
             }
         });

--- a/src/components/comment_input.rs
+++ b/src/components/comment_input.rs
@@ -14,6 +14,8 @@ pub struct CommentInput {
     pub file_path: String,
     pub line: usize,
     pub side: crate::types::Side,
+    pub reply_to_id: Option<u64>,
+    pub reply_author: String,
 }
 
 pub enum CommentAction {
@@ -32,6 +34,8 @@ impl CommentInput {
             file_path: String::new(),
             line: 0,
             side: crate::types::Side::Right,
+            reply_to_id: None,
+            reply_author: String::new(),
         }
     }
 
@@ -41,6 +45,16 @@ impl CommentInput {
         self.file_path = file_path;
         self.line = line;
         self.side = side;
+        self.reply_to_id = None;
+        self.reply_author.clear();
+        self.visible = true;
+    }
+
+    pub fn open_reply(&mut self, comment_id: u64, author: String) {
+        self.textarea = TextArea::default();
+        self.textarea.set_cursor_line_style(Style::default());
+        self.reply_to_id = Some(comment_id);
+        self.reply_author = author;
         self.visible = true;
     }
 
@@ -85,7 +99,11 @@ impl CommentInput {
         // Clear the background
         Widget::render(Clear, popup_area, buf);
 
-        let title = format!(" Comment on {}:{} ", self.file_path, self.line);
+        let title = if self.reply_to_id.is_some() {
+            format!(" Reply to @{} ", self.reply_author)
+        } else {
+            format!(" Comment on {}:{} ", self.file_path, self.line)
+        };
         let block = Block::default()
             .title(title)
             .borders(Borders::ALL)

--- a/src/components/diff_view.rs
+++ b/src/components/diff_view.rs
@@ -58,7 +58,41 @@ impl DiffView {
         }
     }
 
-    // --- Comment expand ---
+    // --- Comment helpers ---
+
+    /// If cursor is on a comment row, walk back to the nearest CommentHeader and
+    /// return the GitHub API ID + author so we can post a reply.
+    pub fn comment_reply_target(&self) -> Option<ReplyTarget> {
+        match self.display_rows.get(self.cursor) {
+            Some(DisplayRow::CommentHeader { .. })
+            | Some(DisplayRow::CommentBodyLine { .. })
+            | Some(DisplayRow::CommentFooter) => {}
+            _ => return None,
+        }
+
+        for i in (0..=self.cursor).rev() {
+            match self.display_rows.get(i) {
+                Some(DisplayRow::CommentHeader {
+                    github_id: Some(gid),
+                    author,
+                    ..
+                }) => {
+                    return Some(ReplyTarget {
+                        github_id: *gid,
+                        author: author.clone(),
+                    });
+                }
+                Some(DisplayRow::CommentHeader {
+                    github_id: None, ..
+                }) => return None,
+                Some(DisplayRow::CommentBodyLine { .. }) | Some(DisplayRow::CommentFooter) => {
+                    continue
+                }
+                _ => return None,
+            }
+        }
+        None
+    }
 
     /// Toggle expand/collapse if cursor is on a comment row. Returns true if toggled.
     pub fn toggle_comment_expand(&mut self) -> bool {
@@ -467,4 +501,9 @@ pub struct CommentTarget {
     pub file_idx: usize,
     pub line: usize,
     pub side: crate::types::Side,
+}
+
+pub struct ReplyTarget {
+    pub github_id: u64,
+    pub author: String,
 }

--- a/src/diff/renderer.rs
+++ b/src/diff/renderer.rs
@@ -4,7 +4,7 @@ use ratatui::{
 };
 
 use crate::theme::Theme;
-use crate::types::{DiffFile, DiffLine, ExistingComment, LineKind, ReviewComment};
+use crate::types::{DiffFile, DiffLine, ExistingComment, LineKind, ReviewComment, Side};
 
 #[derive(Debug, Clone)]
 pub enum DisplayRow {
@@ -32,6 +32,7 @@ pub enum DisplayRow {
         author: String,
         is_pending: bool,
         comment_id: usize,
+        github_id: Option<u64>,
         expanded: bool,
         body_preview: String,
         body_lines: usize,
@@ -95,15 +96,22 @@ pub fn build_display_rows(
                     line_idx,
                 });
 
-                let target_line = match line.kind {
-                    LineKind::Added | LineKind::Context => line.new_lineno,
-                    LineKind::Removed => line.old_lineno,
+                let (target_line, target_side) = match line.kind {
+                    LineKind::Added | LineKind::Context => (line.new_lineno, Side::Right),
+                    LineKind::Removed => (line.old_lineno, Side::Left),
                 };
 
                 if let Some(lineno) = target_line {
-                    for ec in existing_comments
-                        .iter()
-                        .filter(|c| c.path == file.path && c.line == Some(lineno))
+                    for ec in existing_comments.iter().filter(|c| {
+                        c.path == file.path
+                            && c.line == Some(lineno)
+                            && match (c.side.as_deref(), &target_side) {
+                                (Some("LEFT"), Side::Left)
+                                | (Some("RIGHT"), Side::Right) => true,
+                                (None, _) => true,
+                                _ => false,
+                            }
+                    })
                     {
                         let cid = comment_id_counter;
                         comment_id_counter += 1;
@@ -115,6 +123,7 @@ pub fn build_display_rows(
                             author: ec.user.login.clone(),
                             is_pending: false,
                             comment_id: cid,
+                            github_id: Some(ec.id),
                             expanded: is_expanded,
                             body_preview: preview,
                             body_lines,
@@ -131,7 +140,7 @@ pub fn build_display_rows(
 
                     for pc in pending_comments
                         .iter()
-                        .filter(|c| c.path == file.path && c.line == lineno)
+                        .filter(|c| c.path == file.path && c.line == lineno && c.side == target_side)
                     {
                         let cid = comment_id_counter;
                         comment_id_counter += 1;
@@ -143,6 +152,7 @@ pub fn build_display_rows(
                             author: String::new(),
                             is_pending: true,
                             comment_id: cid,
+                            github_id: None,
                             expanded: is_expanded,
                             body_preview: preview,
                             body_lines,

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -76,6 +76,38 @@ pub async fn fetch_file_content(repo: &str, path: &str, git_ref: &str) -> Result
     }
 }
 
+pub async fn reply_to_comment(
+    repo: &str,
+    pr_number: u64,
+    comment_id: u64,
+    body: &str,
+) -> Result<()> {
+    let url = format!("repos/{repo}/pulls/{pr_number}/comments/{comment_id}/replies");
+    let json_body = serde_json::json!({ "body": body });
+    let json_str = serde_json::to_string(&json_body)?;
+
+    let mut child = Command::new("gh")
+        .args(["api", &url, "-X", "POST", "--input", "-"])
+        .kill_on_drop(true)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()?;
+
+    use tokio::io::AsyncWriteExt;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(json_str.as_bytes()).await?;
+    }
+
+    let output = child.wait_with_output().await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("Failed to post reply: {}", stderr.trim());
+    }
+
+    Ok(())
+}
+
 pub async fn submit_review(
     repo: &str,
     pr_number: u64,


### PR DESCRIPTION
Fix duplicate pending comment display 
- Add side (LEFT/RIGHT) matching when rendering comments under diff lines, so a comment no longer appears twice when a removed line and a context line share the same line number.
Reply to comments 
- Pressing c on an existing comment opens a reply popup (posted immediately via the GitHub API); pressing c on a diff line still creates a new review comment.
e expands comments 
- The e key now also toggles comment expand/collapse (falls back to context expansion on diff lines).

---
**Stack**:
- #5 ⬅
- #4
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*