### PR TITLE
Migrate `submit_review` from REST to GraphQL API

### DIFF
--- a/src/gh.rs
+++ b/src/gh.rs
@@ -393,43 +393,78 @@ pub async fn submit_review(
     body: &str,
     comments: &[ReviewComment],
 ) -> Result<()> {
-    let url = format!("repos/{repo}/pulls/{pr_number}/reviews");
+    let (owner, name) = repo
+        .split_once('/')
+        .context("Invalid repo format, expected owner/name")?;
 
-    let comments_json: Vec<serde_json::Value> = comments
+    let pr_id = fetch_pr_node_id(owner, name, pr_number).await?;
+
+    let side_str = |s: crate::types::Side| match s {
+        crate::types::Side::Left => "LEFT",
+        crate::types::Side::Right => "RIGHT",
+    };
+
+    let threads: Vec<serde_json::Value> = comments
         .iter()
         .map(|c| {
-            let side_str = match c.side {
-                crate::types::Side::Left => "LEFT",
-                crate::types::Side::Right => "RIGHT",
-            };
             let mut obj = serde_json::json!({
                 "path": c.path,
                 "line": c.line,
-                "side": side_str,
+                "side": side_str(c.side),
                 "body": c.body
             });
             if let Some(sl) = c.start_line {
-                obj["start_line"] = serde_json::json!(sl);
+                obj["startLine"] = serde_json::json!(sl);
             }
             if let Some(ss) = c.start_side {
-                obj["start_side"] = serde_json::json!(match ss {
-                    crate::types::Side::Left => "LEFT",
-                    crate::types::Side::Right => "RIGHT",
-                });
+                obj["startSide"] = serde_json::json!(side_str(ss));
             }
             obj
         })
         .collect();
 
-    let json_body = serde_json::json!({
-        "event": event.as_api_str(),
-        "body": body,
-        "comments": comments_json
-    });
+    let mutation = r#"
+        mutation($input: AddPullRequestReviewInput!) {
+            addPullRequestReview(input: $input) {
+                pullRequestReview { id }
+            }
+        }
+    "#;
 
-    let json_str = serde_json::to_string(&json_body)?;
-    run_gh_with_stdin(&["api", &url, "-X", "POST", "--input", "-"], &json_str).await?;
+    let mut input = serde_json::json!({
+        "pullRequestId": pr_id,
+        "event": event.as_api_str(),
+    });
+    if !body.is_empty() {
+        input["body"] = serde_json::json!(body);
+    }
+    if !threads.is_empty() {
+        input["threads"] = serde_json::json!(threads);
+    }
+
+    let result = run_graphql(mutation, &serde_json::json!({ "input": input })).await?;
+    if let Some(errors) = result["errors"].as_array() {
+        if let Some(msg) = errors.first().and_then(|e| e["message"].as_str()) {
+            bail!("{msg}");
+        }
+    }
     Ok(())
+}
+
+async fn fetch_pr_node_id(owner: &str, name: &str, pr_number: u64) -> Result<String> {
+    let query = r#"
+        query($owner: String!, $name: String!, $pr: Int!) {
+            repository(owner: $owner, name: $name) {
+                pullRequest(number: $pr) { id }
+            }
+        }
+    "#;
+    let vars = serde_json::json!({ "owner": owner, "name": name, "pr": pr_number });
+    let result = run_graphql(query, &vars).await?;
+    result["data"]["repository"]["pullRequest"]["id"]
+        .as_str()
+        .map(String::from)
+        .context("Failed to resolve PR node ID")
 }
 
 /// Send a JSON body to `gh api` via stdin and return the raw output.


### PR DESCRIPTION
Replaces the REST `POST /repos/{repo}/pulls/{pr_number}/reviews` call with the `addPullRequestReview` GraphQL mutation to resolve approval submission failures.

- Add `fetch_pr_node_id` helper to resolve the PR's GraphQL node ID before submitting the review
- Extract `side_str` closure to avoid duplicated `Side` → string match arms
- Rename comment fields from snake_case to camelCase (`start_line` → `startLine`, `start_side` → `startSide`) to conform to the GraphQL input schema
- Omit `body` and `threads` from the mutation input when empty, as the GraphQL API rejects blank strings and empty arrays that the REST API accepted silently
- Propagate the first GraphQL error message via `bail!` for clearer failure diagnostics

**Trade-off**: The GraphQL path requires an extra round-trip to fetch the PR node ID, but this is necessary since the `addPullRequestReview` mutation takes a node ID rather than a number.